### PR TITLE
Dispatchable function objects

### DIFF
--- a/include/boost/dispatch/function/functor.hpp
+++ b/include/boost/dispatch/function/functor.hpp
@@ -1,0 +1,76 @@
+//==================================================================================================
+/*
+  Copyright 2009 - 2011 LASMEA UMR 6602 CNRS/Univ. Clermont II
+  Copyright 2009 - 2015 LRI UMR 8623 CNRS/Univ Paris Sud XI
+  Copyright 2012 - 2015 NumScale SAS
+
+  Distributed under the Boost Software License, Version 1.0.
+  (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
+*/
+//==================================================================================================
+#ifndef BOOST_DISPATCH_FUNCTION_FUNCTOR_HPP_INCLUDED
+#define BOOST_DISPATCH_FUNCTION_FUNCTOR_HPP_INCLUDED
+
+#include <boost/dispatch/hierarchy/default_site.hpp>
+#include <boost/dispatch/hierarchy_of.hpp>
+#include <utility>
+
+namespace boost { namespace dispatch
+{
+  /*!
+    @ingroup group-api
+    @brief Adaptable dispactch-enabled function object
+
+    @tparam Tag
+    @tparam Site
+  **/
+  template<typename Tag, typename Site = boost::dispatch::default_site<Tag>>
+  struct functor
+  {
+    /*!
+
+    **/
+    template<typename Other, typename... Args> BOOST_FORCEINLINE
+    auto on(Args&&... args) const
+        -> decltype ( Tag::dispatch_to( Other()
+                                      , boost::dispatch::hierarchy_of<Args>()...
+                                      )( std::forward<Args>(args)...)
+                    )
+    {
+      return Tag::dispatch_to ( Other()
+                              , boost::dispatch::hierarchy_of<Args>()...
+                              )( std::forward<Args>(args)...);
+    }
+
+    /*!
+      @ingroup group-api
+      @brief Architectural target rebinding
+
+      Creates an instance of functor which shares current functor's tag but
+      dispatched over a specific architecture hierarchy.
+
+      @return a instance of functor dispatching specifically on architecture Other
+
+      @tparam Other New architecture target to generate a functor for
+    **/
+    template<typename Other>
+    static BOOST_FORCEINLINE functor<Tag,Other> rebind() { return {}; }
+
+    /*!
+
+    **/
+    template<typename... Args> BOOST_FORCEINLINE
+    auto operator()(Args&&... args) const
+                      -> decltype ( Tag::dispatch_to( Site()
+                                                    , boost::dispatch::hierarchy_of<Args>()...
+                                                    )( std::forward<Args>(args)...)
+                                  )
+    {
+      return Tag::dispatch_to ( Site()
+                              , boost::dispatch::hierarchy_of<Args>()...
+                              )( std::forward<Args>(args)...);
+    }
+  };
+} }
+
+#endif

--- a/include/boost/dispatch/function/functor.hpp
+++ b/include/boost/dispatch/function/functor.hpp
@@ -33,12 +33,12 @@ namespace boost { namespace dispatch
     template<typename Other, typename... Args> BOOST_FORCEINLINE
     auto on(Args&&... args) const
         -> decltype ( Tag::dispatch_to( Other()
-                                      , boost::dispatch::hierarchy_of<Args>()...
+                                      , boost::dispatch::hierarchy_of_t<Args>()...
                                       )( std::forward<Args>(args)...)
                     )
     {
       return Tag::dispatch_to ( Other()
-                              , boost::dispatch::hierarchy_of<Args>()...
+                              , boost::dispatch::hierarchy_of_t<Args>()...
                               )( std::forward<Args>(args)...);
     }
 
@@ -62,12 +62,12 @@ namespace boost { namespace dispatch
     template<typename... Args> BOOST_FORCEINLINE
     auto operator()(Args&&... args) const
                       -> decltype ( Tag::dispatch_to( Site()
-                                                    , boost::dispatch::hierarchy_of<Args>()...
+                                                    , boost::dispatch::hierarchy_of_t<Args>()...
                                                     )( std::forward<Args>(args)...)
                                   )
     {
       return Tag::dispatch_to ( Site()
-                              , boost::dispatch::hierarchy_of<Args>()...
+                              , boost::dispatch::hierarchy_of_t<Args>()...
                               )( std::forward<Args>(args)...);
     }
   };

--- a/include/boost/dispatch/function/make_callable.hpp
+++ b/include/boost/dispatch/function/make_callable.hpp
@@ -1,0 +1,81 @@
+//==================================================================================================
+/*!
+  @file
+
+  Provides the callable object registration macro
+
+  @copyright 2009 - 2012 LASMEA UMR 6602 CNRS/Univ. Clermont II
+  @copyright 2009 - 2015 LRI UMR 8623 CNRS/Univ Paris Sud XI
+  @copyright 2012 - 2015 NumScale SAS
+
+  Distributed under the Boost Software License, Version 1.0.
+  (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
+
+**/
+//==================================================================================================
+#ifndef BOOST_DISPATCH_FUNCTION_MAKE_CALLABLE_HPP_INCLUDED
+#define BOOST_DISPATCH_FUNCTION_MAKE_CALLABLE_HPP_INCLUDED
+
+#include <boost/dispatch/function/overload.hpp>
+#include <boost/dispatch/function/functor.hpp>
+#include <boost/dispatch/hierarchy/base.hpp>
+#include <boost/dispatch/detail/auto_decltype.hpp>
+
+/*!
+  @ingroup group-api
+
+  Generates the boilerplate code for adapting a @c TAG type as a Boost.Dispatch callable
+  object
+
+  @par Usage:
+
+  @param TAG    Tag type to be implemented
+  @param PARENT Tag's parent hierarchy
+**/
+#define BOOST_DISPATCH_MAKE_CALLABLE(TAG,PARENT)                                                    \
+template<typename... Args>                                                                          \
+static BOOST_FORCEINLINE BOOST_AUTO_DECLTYPE dispatch_to(Args&&... args)                            \
+BOOST_AUTO_DECLTYPE_BODY( BOOST_DISPATCH_DISPATCHING_FUNCTION(TAG)                                  \
+                          (ext::adl_helper(), std::forward<Args>(args)...)                          \
+                        )                                                                           \
+using parent = PARENT                                                                               \
+/**/
+
+/*!
+  @ingroup group-api
+
+  Generates the boilerplate code for defining the dispatching function for a given @c TAG
+
+  @par Usage:
+
+  @param NAMESPACE  Namespace containing @c TAG
+  @param TAG        Tag type identifier
+**/
+#define BOOST_DISPATCH_FUNCTION_DECLARATION(NAMESPACE,TAG)                                          \
+template<typename... T> struct impl_##TAG;                                                          \
+template<typename Site>                                                                             \
+inline generic_dispatcher<NAMESPACE::TAG>                                                           \
+BOOST_DISPATCH_DISPATCHING_FUNCTION(TAG)( adl_helper const&                                         \
+                                        , ::boost::dispatch::unspecified_<Site> const&              \
+                                        , ...                                                       \
+                                        )                                                           \
+{                                                                                                   \
+  return {};                                                                                        \
+}                                                                                                   \
+/**/
+
+/*!
+  @ingroup group-api
+
+  Generates a callable object from a @c TAG
+
+  @par Usage:
+
+  @param TAG  Fully qualified tag type to adapt
+  @param NAME Callable object identifier
+**/
+#define BOOST_DISPATCH_FUNCTION_DEFINITION(TAG,NAME)                                                \
+static const boost::dispatch::functor<TAG> NAME = {}                                                \
+/**/
+
+#endif

--- a/include/boost/dispatch/function/make_callable.hpp
+++ b/include/boost/dispatch/function/make_callable.hpp
@@ -32,11 +32,11 @@
   @param TAG    Tag type to be implemented
   @param PARENT Tag's parent hierarchy
 **/
-#define BOOST_DISPATCH_MAKE_CALLABLE(TAG,PARENT)                                                    \
+#define BOOST_DISPATCH_MAKE_CALLABLE(NS,TAG,PARENT)                                                 \
 template<typename... Args>                                                                          \
 static BOOST_FORCEINLINE BOOST_AUTO_DECLTYPE dispatch_to(Args&&... args)                            \
 BOOST_AUTO_DECLTYPE_BODY( BOOST_DISPATCH_DISPATCHING_FUNCTION(TAG)                                  \
-                          (ext::adl_helper(), std::forward<Args>(args)...)                          \
+                          (NS::adl_helper(), std::forward<Args>(args)...)                           \
                         )                                                                           \
 using parent = PARENT                                                                               \
 /**/
@@ -52,8 +52,8 @@ using parent = PARENT                                                           
   @param TAG    Tag type to be implemented
   @param PARENT Tag's parent hierarchy
 **/
-#define BOOST_DISPATCH_MAKE_TAG(TAG, PARENT)                                                        \
-struct TAG : PARENT { BOOST_DISPATCH_MAKE_CALLABLE(TAG,PARENT); }                                   \
+#define BOOST_DISPATCH_MAKE_TAG(NS,TAG, PARENT)                                                     \
+struct TAG : PARENT { BOOST_DISPATCH_MAKE_CALLABLE(NS,TAG,PARENT); }                                \
 /**/
 
 /*!

--- a/include/boost/dispatch/function/make_callable.hpp
+++ b/include/boost/dispatch/function/make_callable.hpp
@@ -67,6 +67,7 @@ struct TAG : PARENT { BOOST_DISPATCH_MAKE_CALLABLE(TAG,PARENT); }               
   @param TAG        Tag type identifier
 **/
 #define BOOST_DISPATCH_FUNCTION_DECLARATION(NAMESPACE,TAG)                                          \
+template<typename... Specifications> struct impl_##TAG;                                             \
 template<typename Site>                                                                             \
 inline generic_dispatcher<NAMESPACE::TAG>                                                           \
 BOOST_DISPATCH_IMPLEMENTS(TAG, ::boost::dispatch::unspecified_<Site> const&, ... )                  \

--- a/include/boost/dispatch/function/make_callable.hpp
+++ b/include/boost/dispatch/function/make_callable.hpp
@@ -44,6 +44,21 @@ using parent = PARENT                                                           
 /*!
   @ingroup group-api
 
+  Generates the boilerplate code for generating a @c TAG type as
+  a Boost.Dispatch callable object
+
+  @par Usage:
+
+  @param TAG    Tag type to be implemented
+  @param PARENT Tag's parent hierarchy
+**/
+#define BOOST_DISPATCH_MAKE_TAG(TAG, PARENT)                                                        \
+struct TAG : PARENT { BOOST_DISPATCH_MAKE_CALLABLE(TAG,PARENT); }                                   \
+/**/
+
+/*!
+  @ingroup group-api
+
   Generates the boilerplate code for defining the dispatching function for a given @c TAG
 
   @par Usage:
@@ -52,13 +67,9 @@ using parent = PARENT                                                           
   @param TAG        Tag type identifier
 **/
 #define BOOST_DISPATCH_FUNCTION_DECLARATION(NAMESPACE,TAG)                                          \
-template<typename... T> struct impl_##TAG;                                                          \
 template<typename Site>                                                                             \
 inline generic_dispatcher<NAMESPACE::TAG>                                                           \
-BOOST_DISPATCH_DISPATCHING_FUNCTION(TAG)( adl_helper const&                                         \
-                                        , ::boost::dispatch::unspecified_<Site> const&              \
-                                        , ...                                                       \
-                                        )                                                           \
+BOOST_DISPATCH_IMPLEMENTS(TAG, ::boost::dispatch::unspecified_<Site> const&, ... )                  \
 {                                                                                                   \
   return {};                                                                                        \
 }                                                                                                   \

--- a/include/boost/dispatch/function/overload.hpp
+++ b/include/boost/dispatch/function/overload.hpp
@@ -17,7 +17,7 @@
 #define BOOST_DISPATCH_FUNCTION_OVERLOAD_HPP_INCLUDED
 
 #include <boost/preprocessor/cat.hpp>
-
+#include <boost/preprocessor/tuple/rem.hpp>
 /*!
   @ingroup group-api
 
@@ -37,5 +37,14 @@ BOOST_DISPATCH_DISPATCHING_FUNCTION(TAG)( adl_helper const&, __VA_ARGS__)       
 
 **/
 #define BOOST_DISPATCH_FALLBACK(...) dispatching( adl_helper const&, __VA_ARGS__)
+
+/*!
+
+**/
+#define BOOST_DISPATCH_OVERLOAD(TAG, TEMPLATES, ... )                                               \
+template<BOOST_PP_TUPLE_REM_CTOR(TEMPLATES)>                                                        \
+BOOST_PP_CAT(impl_,TAG)<__VA_ARGS__> BOOST_DISPATCH_IMPLEMENTS(TAG,__VA_ARGS__) { return {}; }      \
+template<BOOST_PP_TUPLE_REM_CTOR(TEMPLATES)> struct BOOST_PP_CAT(impl_,TAG)<__VA_ARGS__>            \
+/**/
 
 #endif

--- a/include/boost/dispatch/function/overload.hpp
+++ b/include/boost/dispatch/function/overload.hpp
@@ -27,4 +27,15 @@
 **/
 #define BOOST_DISPATCH_DISPATCHING_FUNCTION(TAG) BOOST_PP_CAT(dispatching_, TAG)
 
+/*!
+
+**/
+#define BOOST_DISPATCH_IMPLEMENTS(TAG, ...)                                                         \
+BOOST_DISPATCH_DISPATCHING_FUNCTION(TAG)( adl_helper const&, __VA_ARGS__)                           \
+
+/*!
+
+**/
+#define BOOST_DISPATCH_FALLBACK(...) dispatching( adl_helper const&, __VA_ARGS__)
+
 #endif

--- a/include/boost/dispatch/function/overload.hpp
+++ b/include/boost/dispatch/function/overload.hpp
@@ -1,0 +1,30 @@
+//==================================================================================================
+/*!
+  @file
+
+  Provides macros for function overload definition and declaration
+
+  @copyright 2009 - 2012 LASMEA UMR 6602 CNRS/Univ. Clermont II
+  @copyright 2009 - 2015 LRI UMR 8623 CNRS/Univ Paris Sud XI
+  @copyright 2012 - 2015 NumScale SAS
+
+  Distributed under the Boost Software License, Version 1.0.
+  (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
+
+**/
+//==================================================================================================
+#ifndef BOOST_DISPATCH_FUNCTION_OVERLOAD_HPP_INCLUDED
+#define BOOST_DISPATCH_FUNCTION_OVERLOAD_HPP_INCLUDED
+
+#include <boost/preprocessor/cat.hpp>
+
+/*!
+  @ingroup group-api
+
+  Provides the name of the dispatching function for a given @c TAG
+
+  @param TAG Tag of the function to dispatch
+**/
+#define BOOST_DISPATCH_DISPATCHING_FUNCTION(TAG) BOOST_PP_CAT(dispatching_, TAG)
+
+#endif

--- a/include/boost/dispatch/function/overload.hpp
+++ b/include/boost/dispatch/function/overload.hpp
@@ -47,4 +47,14 @@ BOOST_PP_CAT(impl_,TAG)<__VA_ARGS__> BOOST_DISPATCH_IMPLEMENTS(TAG,__VA_ARGS__) 
 template<BOOST_PP_TUPLE_REM_CTOR(TEMPLATES)> struct BOOST_PP_CAT(impl_,TAG)<__VA_ARGS__>            \
 /**/
 
+/*!
+
+**/
+#define BOOST_DISPATCH_OVERLOAD_FALLBACK( TEMPLATES, ... )                                          \
+template<typename... Specifications> struct impl_fallback;                                          \
+template<BOOST_PP_TUPLE_REM_CTOR(TEMPLATES)>                                                        \
+impl_fallback<__VA_ARGS__> dispatching( adl_helper const&, __VA_ARGS__) { return {}; }              \
+template<BOOST_PP_TUPLE_REM_CTOR(TEMPLATES)> struct impl_fallback<__VA_ARGS__>                      \
+/**/
+
 #endif

--- a/include/boost/dispatch/function/register_namespace.hpp
+++ b/include/boost/dispatch/function/register_namespace.hpp
@@ -12,7 +12,7 @@
   (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
 
 **/
-//=================================================deaut=================================================
+//==================================================================================================
 #ifndef BOOST_DISPATCH_FUNCTION_REGISTER_NAMESPACE_HPP_INCLUDED
 #define BOOST_DISPATCH_FUNCTION_REGISTER_NAMESPACE_HPP_INCLUDED
 
@@ -102,31 +102,28 @@ namespace boost { namespace dispatch
   using generic_dispatcher = detail::generic_dispatcher<meta::adl_helper,Tag>;
 } }
 
+// enlever namesapace NMESPACE de la macro
 /*!
   @ingroup group-api
 
-  Make a @c NAMESPACE able to house dispatchable function overloads and to use a @c FALLBAKC
+  Make the current namespace able to house dispatchable function overloads and to use a @c FALLBAKC
   namespace if the current one fails to provide any viable overload.
 
-  @param NAMESPACE  Namespace name to be registered
   @param FALLBACK   Namespace to use in fallback situations
 **/
-#define BOOST_DISPATCH_REGISTER_NAMESPACE(NAMESPACE, FALLBACK)                                      \
-namespace NAMESPACE                                                                                 \
-{                                                                                                   \
-  struct adl_helper {};                                                                             \
+#define BOOST_DISPATCH_REGISTER_NAMESPACE(FALLBACK)                                                 \
+struct adl_helper {};                                                                               \
                                                                                                     \
-  template<typename Tag, typename Site>                                                             \
-  inline FALLBACK::generic_dispatcher<Tag>                                                          \
-  dispatching ( adl_helper const&, ::boost::dispatch::function_<Tag> const&                         \
-              , ::boost::dispatch::unspecified_<Site> const&, ...                                   \
-              )                                                                                     \
-  {                                                                                                 \
-    return {};                                                                                      \
-  }                                                                                                 \
+template<typename Tag, typename Site>                                                               \
+inline FALLBACK::generic_dispatcher<Tag>                                                            \
+dispatching ( adl_helper const&, ::boost::dispatch::function_<Tag> const&                           \
+            , ::boost::dispatch::unspecified_<Site> const&, ...                                     \
+            )                                                                                       \
+{                                                                                                   \
+  return {};                                                                                        \
 }                                                                                                   \
 template<typename Tag>                                                                              \
-using generic_dispatcher = ::boost::dispatch::detail::generic_dispatcher<NAMESPACE::adl_helper,Tag> \
+using generic_dispatcher = ::boost::dispatch::detail::generic_dispatcher<adl_helper,Tag>            \
 /**/
 
 #endif

--- a/include/boost/dispatch/function/register_namespace.hpp
+++ b/include/boost/dispatch/function/register_namespace.hpp
@@ -1,0 +1,132 @@
+//==================================================================================================
+/*!
+  @file
+
+  Provides the macro performing namespace registration
+
+  @copyright 2009 - 2012 LASMEA UMR 6602 CNRS/Univ. Clermont II
+  @copyright 2009 - 2015 LRI UMR 8623 CNRS/Univ Paris Sud XI
+  @copyright 2012 - 2015 NumScale SAS
+
+  Distributed under the Boost Software License, Version 1.0.
+  (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
+
+**/
+//=================================================deaut=================================================
+#ifndef BOOST_DISPATCH_FUNCTION_REGISTER_NAMESPACE_HPP_INCLUDED
+#define BOOST_DISPATCH_FUNCTION_REGISTER_NAMESPACE_HPP_INCLUDED
+
+#include <boost/dispatch/hierarchy/default_site.hpp>
+#include <boost/dispatch/hierarchy/unspecified.hpp>
+#include <boost/dispatch/hierarchy/base.hpp>
+#include <boost/dispatch/hierarchy_of.hpp>
+#include <boost/utility/result_of.hpp>
+#include <boost/config.hpp>
+#include <utility>
+
+namespace boost { namespace dispatch
+{
+  namespace meta { struct adl_helper {}; }
+
+  /*!
+    @ingroup group-api
+    @brief Error reporting utility dispatcher.
+
+    Whenver a dispatchable function ends up with no suitable overloads, this dispatcher will cause
+    a compilation error by producing an incomplete type which type contains the function tag used,
+    the architecture hierarchy and the list of types passed as parameters.
+
+    @par Usage:
+
+  **/
+  template<typename Tag, typename Site> struct error_
+  {
+    /// Error inducing information carrier
+    template<typename... Call> struct no_such_overload;
+
+    template<typename... Ts>
+    BOOST_FORCEINLINE no_such_overload<Tag(Site,Ts...)> operator()(Ts&& ...) const { return {}; }
+  };
+
+  namespace meta
+  {
+    // The 'no luck Sherlock' case returns an incomplete type to emit an informative message
+    template<typename F, typename A>
+    inline error_<F,A> dispatching(adl_helper const&,function_<F> const&,unspecified_<A> const&,...)
+    {
+      return {};
+    }
+  }
+
+  namespace detail
+  {
+    template<typename Discriminant,typename Tag> struct generic_dispatcher
+    {
+      // While ICC supports decltype-SFINAE, it causes infinite compilation times in some cases
+      #if defined(BOOST_NO_SFINAE_EXPR) || defined(__INTEL_COMPILER)
+      template<typename Sig> struct result;
+      template<typename This, typename... Args>
+      struct result<This(Args...)>
+           : boost::result_of
+                    < decltype( dispatching ( Discriminant{}, Tag{}, default_site<Tag>{}
+                                            , ::boost::dispatch::hierarchy_of<Args&&>()...
+                                            )
+                              )(Args...)
+                    >
+      {};
+
+      template<typename... Args>
+      BOOST_FORCEINLINE typename result<generic_dispatcher(Args&&...)>::type
+      operator()(Args&&... args) const
+      {
+        return dispatching( Discriminant{}, Tag{}, default_site<Tag>{}
+                          , ::boost::dispatch::hierarchy_of<Args&&>()...
+                          )
+                          ( std::forward<Args>(args)... );
+      }
+      #else
+      template<typename... Args>
+      BOOST_FORCEINLINE auto operator()(Args&&... args) const
+      BOOST_AUTO_DECLTYPE_BODY_SFINAE
+      (
+        dispatching ( Discriminant{}, Tag{}, default_site<Tag>{}
+                    , ::boost::dispatch::hierarchy_of<Args&&>()...
+                    )( std::forward<Args>(args)... )
+      );
+      #endif
+    };
+  }
+
+  /// Root generic_dispatcher instance
+  template<typename Tag>
+  using generic_dispatcher = detail::generic_dispatcher<meta::adl_helper,Tag>;
+} }
+
+/*!
+  @ingroup group-api
+
+  Make a @c NAMESPACE able to house dispatchable function overloads and to use a @c FALLBAKC
+  namespace if the current one fails to provide any viable overload.
+
+  @param NAMESPACE  Namespace name to be registered
+  @param FALLBACK   Namespace to use in fallback situations
+**/
+#define BOOST_DISPATCH_REGISTER_NAMESPACE(NAMESPACE, FALLBACK)                                      \
+namespace NAMESPACE                                                                                 \
+{                                                                                                   \
+  struct adl_helper {};                                                                             \
+                                                                                                    \
+  template<typename Tag, typename Site>                                                             \
+  inline FALLBACK::generic_dispatcher<Tag>                                                          \
+  dispatching ( adl_helper const&, ::boost::dispatch::function_<Tag> const&                         \
+              , ::boost::dispatch::unspecified_<Site> const&, ...                                   \
+              )                                                                                     \
+  {                                                                                                 \
+    return {};                                                                                      \
+  }                                                                                                 \
+}                                                                                                   \
+template<typename Tag>                                                                              \
+using generic_dispatcher = ::boost::dispatch::detail::generic_dispatcher<NAMESPACE::adl_helper,Tag> \
+/**/
+
+#endif

--- a/include/boost/dispatch/function/register_namespace.hpp
+++ b/include/boost/dispatch/function/register_namespace.hpp
@@ -69,7 +69,7 @@ namespace boost { namespace dispatch
       struct result<This(Args...)>
            : boost::result_of
                     < decltype( dispatching ( Discriminant{}, Tag{}, default_site<Tag>{}
-                                            , ::boost::dispatch::hierarchy_of<Args&&>()...
+                                            , ::boost::dispatch::hierarchy_of_t<Args&&>()...
                                             )
                               )(Args...)
                     >
@@ -80,7 +80,7 @@ namespace boost { namespace dispatch
       operator()(Args&&... args) const
       {
         return dispatching( Discriminant{}, Tag{}, default_site<Tag>{}
-                          , ::boost::dispatch::hierarchy_of<Args&&>()...
+                          , ::boost::dispatch::hierarchy_of_t<Args&&>()...
                           )
                           ( std::forward<Args>(args)... );
       }
@@ -90,7 +90,7 @@ namespace boost { namespace dispatch
       BOOST_AUTO_DECLTYPE_BODY_SFINAE
       (
         dispatching ( Discriminant{}, Tag{}, default_site<Tag>{}
-                    , ::boost::dispatch::hierarchy_of<Args&&>()...
+                    , ::boost::dispatch::hierarchy_of_t<Args&&>()...
                     )( std::forward<Args>(args)... )
       );
       #endif

--- a/include/boost/dispatch/hierarchy/base.hpp
+++ b/include/boost/dispatch/hierarchy/base.hpp
@@ -35,18 +35,6 @@ namespace boost { namespace dispatch
 
   /*!
     @ingroup group-hierarchy
-    @brief Root hardware hierarchy tag
-
-    The architecture_ hierarchy classify hardware related informations.
-  **/
-  template<typename T> struct architecture_
-  {
-    using parent        =  architecture_;
-    using hierarchy_tag =  detail::hierarchy_tag;
-  };
-
-  /*!
-    @ingroup group-hierarchy
     @brief Root function hierarchy tag
 
     The function_ hierarchy classify function related informations.

--- a/include/boost/dispatch/hierarchy/formal.hpp
+++ b/include/boost/dispatch/hierarchy/formal.hpp
@@ -28,9 +28,10 @@ namespace boost { namespace dispatch
     no execution can take place. Functions defined on formal_ hardware are usually trampoline
     function that rewrite or transform code path.
   **/
-  struct formal_ : architecture_<formal_>
+  struct formal_
   {
-    using parent = architecture_<formal_>;
+    using parent        =  formal_;
+    using hierarchy_tag =  detail::hierarchy_tag;
   };
 } }
 

--- a/include/boost/dispatch/hierarchy/formal.hpp
+++ b/include/boost/dispatch/hierarchy/formal.hpp
@@ -16,7 +16,7 @@
 #ifndef BOOST_DISPATCH_HIERARCHY_FORMAL_HPP_INCLUDED
 #define BOOST_DISPATCH_HIERARCHY_FORMAL_HPP_INCLUDED
 
-#include <boost/dispatch/hierarchy/base.hpp>
+#include <boost/dispatch/hierarchy/unspecified.hpp>
 
 namespace boost { namespace dispatch
 {
@@ -28,10 +28,9 @@ namespace boost { namespace dispatch
     no execution can take place. Functions defined on formal_ hardware are usually trampoline
     function that rewrite or transform code path.
   **/
-  struct formal_
+  struct formal_ : unspecified_<formal_>
   {
-    using parent        =  formal_;
-    using hierarchy_tag =  detail::hierarchy_tag;
+    using parent        =  unspecified_<formal_>;
   };
 } }
 

--- a/include/boost/dispatch/hierarchy/functions.hpp
+++ b/include/boost/dispatch/hierarchy/functions.hpp
@@ -22,6 +22,19 @@ namespace boost { namespace dispatch
 {
   /*!
     @ingroup group-hierarchy
+    @brief Abstract function hierarchy tag
+
+    Function object classified as abstract_ if they represent higher-order functions
+
+    @tparam F Function object type
+  **/
+  template<typename F> struct abstract_ : function_<F>
+  {
+    using parent = function_<F>;
+  };
+
+  /*!
+    @ingroup group-hierarchy
     @brief Elementwise function hierarchy tag
 
     Function object classified as elementwise_ if they can be used as argument to the map

--- a/test/api/CMakeLists.txt
+++ b/test/api/CMakeLists.txt
@@ -11,7 +11,7 @@ add_definitions(-DBOOST_ENABLE_ASSERT_HANDLER)
 
 set ( SOURCES
       as.cpp
-#      dispatch.cpp
+      dispatch.cpp
     )
 
 make_unit( "boost.dispatch.api" ${SOURCES})

--- a/test/api/dispatch.cpp
+++ b/test/api/dispatch.cpp
@@ -42,6 +42,7 @@ STF_CASE( "dispatch works correctly using .on<Site>")
 {
   // Different behavior on different arch
   STF_EQUAL(tutu::titi::foo.on<wazoo>('4')  , 'Z'     );
+  STF_EQUAL(tutu::titi::foo.on<wazoo>('A',3), 'D'     );
   STF_EQUAL(tutu::titi::foo.on<wazoo>(4)    , -13.37f );
   STF_EQUAL(tutu::titi::foo.on<wazoo>(4ULL) , 44ULL   );
   STF_EQUAL(tutu::titi::foo.on<wazoo>(4.)   , 0.4     );

--- a/test/hierarchy/parent.cpp
+++ b/test/hierarchy/parent.cpp
@@ -21,12 +21,9 @@ using namespace boost::dispatch;
 
 STF_CASE( "Parenthood of base hierarchies" )
 {
-  STF_TYPE_IS( type_<void>::parent         , type_<void> );
-  STF_TYPE_IS( architecture_<void>::parent , architecture_<void> );
-  STF_TYPE_IS( function_<void>::parent     , function_<void> );
-
-  STF_TYPE_IS( formal_::parent , architecture_<formal_>  );
-  STF_TYPE_IS( cpu_::parent    , formal_                 );
+  STF_TYPE_IS( type_<void>::parent    , type_<void>     );
+  STF_TYPE_IS( function_<void>::parent, function_<void> );
+  STF_TYPE_IS( cpu_::parent           , formal_         );
 }
 
 STF_CASE( "Parenthood of function object hierarchies" )

--- a/test/moc/arch/default/foo.hpp
+++ b/test/moc/arch/default/foo.hpp
@@ -11,7 +11,7 @@
 #ifndef ARCH_DEFAULT_FOO_INCLUDED
 #define ARCH_DEFAULT_FOO_INCLUDED
 
-#include <boost/dispatch/hierarchy/formal.hpp>
+#include <boost/dispatch/hierarchy/cpu.hpp>
 
 namespace boost { namespace dispatch { namespace meta
 {

--- a/test/moc/arch/default/foo.hpp
+++ b/test/moc/arch/default/foo.hpp
@@ -12,6 +12,8 @@
 #define ARCH_DEFAULT_FOO_INCLUDED
 
 #include <boost/dispatch/hierarchy/cpu.hpp>
+#include <boost/dispatch/hierarchy/base.hpp>
+#include <boost/dispatch/hierarchy/functions.hpp>
 
 namespace boost { namespace dispatch { namespace meta
 {
@@ -25,19 +27,10 @@ namespace boost { namespace dispatch { namespace meta
     template<typename T> T operator()(T const& x) { return x*10; }
   };
 
-  template<typename T>
-  dub dispatching ( meta::adl_helper const& , tutu::titi::tag::foo_ const&
-                                      , cpu_ const&
-                                      , type_<T> const&
-                  )
-  {
-    return {};
-  }
-
-  template<typename T>
-  dub2 dispatching ( meta::adl_helper const& , tutu::titi::tag::foo_ const&
-                                      , wazoo const&
-                                      , type_<T> const&
+  template<typename F, typename A, typename T>
+  dub dispatching ( meta::adl_helper const& , function_<F> const&
+                                            , unspecified_<A> const&
+                                            , scalar_<unspecified_<T>> const&
                   )
   {
     return {};

--- a/test/moc/arch/default/foo.hpp
+++ b/test/moc/arch/default/foo.hpp
@@ -22,16 +22,11 @@ namespace boost { namespace dispatch { namespace meta
     template<typename T> T operator()(T const& x) { return x/10; }
   };
 
-  struct dub2
-  {
-    template<typename T> T operator()(T const& x) { return x*10; }
-  };
-
   template<typename F, typename A, typename T>
-  dub dispatching ( meta::adl_helper const& , function_<F> const&
-                                            , unspecified_<A> const&
-                                            , scalar_<unspecified_<T>> const&
-                  )
+  dub BOOST_DISPATCH_FALLBACK ( function_<F> const&
+                              , unspecified_<A> const&
+                              , scalar_<unspecified_<T>> const&
+                              )
   {
     return {};
   }

--- a/test/moc/arch/default/foo.hpp
+++ b/test/moc/arch/default/foo.hpp
@@ -17,19 +17,14 @@
 
 namespace boost { namespace dispatch { namespace meta
 {
-  struct dub
+  BOOST_DISPATCH_OVERLOAD_FALLBACK( (typename F, typename A, typename T)
+                                  , function_<F> const&
+                                  , unspecified_<A> const&
+                                  , scalar_<unspecified_<T>> const&
+                                  )
   {
-    template<typename T> T operator()(T const& x) { return x/10; }
+    T operator()(T const& x) { return x/10; }
   };
-
-  template<typename F, typename A, typename T>
-  dub BOOST_DISPATCH_FALLBACK ( function_<F> const&
-                              , unspecified_<A> const&
-                              , scalar_<unspecified_<T>> const&
-                              )
-  {
-    return {};
-  }
 } } }
 
 #endif

--- a/test/moc/arch/toto/foo.hpp
+++ b/test/moc/arch/toto/foo.hpp
@@ -13,11 +13,6 @@
 
 namespace tutu { namespace titi { namespace ext
 {
-  template<typename T> struct impl_foo_<boost::dispatch::scalar_<boost::dispatch::int_<T>>>
-  {
-    float operator()( T ) const { return -13.37f; }
-  };
-
   struct dub
   {
     template<typename T> T operator()(T const& x) { return x*11; }
@@ -25,19 +20,24 @@ namespace tutu { namespace titi { namespace ext
 
 
   template<typename F, typename T>
-  dub dispatching ( adl_helper const& , boost::dispatch::elementwise_<F> const&
-                                      , boost::dispatch::cpu_ const&
-                                      , boost::dispatch::scalar_<boost::dispatch::integer_<T>> const&
-                  )
+  dub BOOST_DISPATCH_FALLBACK ( boost::dispatch::elementwise_<F> const&
+                              , boost::dispatch::cpu_ const&
+                              , boost::dispatch::scalar_<boost::dispatch::integer_<T>> const&
+                              )
   {
     return {};
   }
 
+  struct int_foo
+  {
+    template<typename T> float operator()( T ) const { return -13.37f; }
+  };
+
   template<typename T>
-  impl_foo_<boost::dispatch::scalar_<boost::dispatch::int_<T>>>
-  dispatching_foo_( adl_helper const&, boost::dispatch::cpu_ const&
-                  , boost::dispatch::scalar_<boost::dispatch::int_<T>> const&
-                  )
+  int_foo BOOST_DISPATCH_IMPLEMENTS ( foo_
+                                    , boost::dispatch::cpu_ const&
+                                    , boost::dispatch::scalar_<boost::dispatch::int_<T>> const&
+                                    )
   {
     return {};
   }

--- a/test/moc/arch/toto/foo.hpp
+++ b/test/moc/arch/toto/foo.hpp
@@ -13,19 +13,35 @@
 
 namespace tutu { namespace titi { namespace ext
 {
-  template<typename T> struct impl_foo<boost::dispatch::scalar_<boost::dispatch::int_<T>>>
+  template<typename T> struct impl_foo_<boost::dispatch::scalar_<boost::dispatch::int_<T>>>
   {
     float operator()( T ) const { return -13.37f; }
   };
 
+  struct dub
+  {
+    template<typename T> T operator()(T const& x) { return x*11; }
+  };
+
+
+  template<typename F, typename T>
+  dub dispatching ( adl_helper const& , boost::dispatch::elementwise_<F> const&
+                                      , boost::dispatch::cpu_ const&
+                                      , boost::dispatch::scalar_<boost::dispatch::integer_<T>> const&
+                  )
+  {
+    return {};
+  }
+
   template<typename T>
-  impl_foo<boost::dispatch::scalar_<boost::dispatch::int_<T>>>
+  impl_foo_<boost::dispatch::scalar_<boost::dispatch::int_<T>>>
   dispatching_foo_( adl_helper const&, boost::dispatch::cpu_ const&
                   , boost::dispatch::scalar_<boost::dispatch::int_<T>> const&
                   )
   {
     return {};
   }
+
 } } }
 
 #endif

--- a/test/moc/arch/tutu/foo.hpp
+++ b/test/moc/arch/tutu/foo.hpp
@@ -11,8 +11,6 @@
 #ifndef ARCH_TUTU_FOO_INCLUDED
 #define ARCH_TUTU_FOO_INCLUDED
 
-#include <string>
-
 namespace tutu { namespace titi { namespace ext
 {
   template<typename T> struct impl_foo<boost::dispatch::scalar_<boost::dispatch::int8_<T>>>
@@ -22,7 +20,7 @@ namespace tutu { namespace titi { namespace ext
 
   struct bob
   {
-    template<typename T> std::string operator()(T) { return "wazzoo #"; }
+    template<typename T> char operator()(T) const { return 'Z'; }
   };
 
   template<typename T>

--- a/test/moc/arch/tutu/foo.hpp
+++ b/test/moc/arch/tutu/foo.hpp
@@ -13,10 +13,19 @@
 
 namespace tutu { namespace titi { namespace ext
 {
-  template<typename T> struct impl_foo_<boost::dispatch::scalar_<boost::dispatch::int8_<T>>>
+  struct int8_foo
   {
-    char operator()( T ) const { return '#'; }
+    template<typename T> char operator()( T ) const { return '#'; }
   };
+
+  template<typename T>
+  int8_foo BOOST_DISPATCH_IMPLEMENTS( foo_
+                                    , boost::dispatch::cpu_ const&
+                                    , boost::dispatch::scalar_<boost::dispatch::int8_<T>> const&
+                                    )
+  {
+    return {};
+  }
 
   struct bob
   {
@@ -24,19 +33,10 @@ namespace tutu { namespace titi { namespace ext
   };
 
   template<typename T>
-  impl_foo_<boost::dispatch::scalar_<boost::dispatch::int8_<T>>>
-  dispatching_foo_( adl_helper const&, boost::dispatch::cpu_ const&
-                  , boost::dispatch::scalar_<boost::dispatch::int8_<T>> const&
-                  )
-  {
-    return {};
-  }
-
-  template<typename T>
-  bob
-  dispatching_foo_( adl_helper const&, wazoo const&
-                  , boost::dispatch::scalar_<boost::dispatch::int8_<T>> const&
-                  )
+  bob BOOST_DISPATCH_IMPLEMENTS ( foo_
+                                , wazoo const&
+                                , boost::dispatch::scalar_<boost::dispatch::int8_<T>> const&
+                                )
   {
     return {};
   }

--- a/test/moc/arch/tutu/foo.hpp
+++ b/test/moc/arch/tutu/foo.hpp
@@ -11,35 +11,37 @@
 #ifndef ARCH_TUTU_FOO_INCLUDED
 #define ARCH_TUTU_FOO_INCLUDED
 
+#include <boost/dispatch/function/overload.hpp>
+
 namespace tutu { namespace titi { namespace ext
 {
-  struct int8_foo
+  BOOST_DISPATCH_OVERLOAD ( foo_
+                          , (typename T)
+                          , boost::dispatch::cpu_
+                          , boost::dispatch::scalar_<boost::dispatch::int8_<T>>
+                          )
   {
-    template<typename T> char operator()( T ) const { return '#'; }
+    char operator()( T const& ) const { return '#'; }
   };
 
-  template<typename T>
-  int8_foo BOOST_DISPATCH_IMPLEMENTS( foo_
-                                    , boost::dispatch::cpu_ const&
-                                    , boost::dispatch::scalar_<boost::dispatch::int8_<T>> const&
-                                    )
+  BOOST_DISPATCH_OVERLOAD ( foo_
+                          , (typename T)
+                          , wazoo
+                          , boost::dispatch::scalar_<boost::dispatch::int8_<T>>
+                          )
   {
-    return {};
-  }
-
-  struct bob
-  {
-    template<typename T> char operator()(T) const { return 'Z'; }
+    char operator()(T) const { return 'Z'; }
   };
 
-  template<typename T>
-  bob BOOST_DISPATCH_IMPLEMENTS ( foo_
-                                , wazoo const&
-                                , boost::dispatch::scalar_<boost::dispatch::int8_<T>> const&
-                                )
+  BOOST_DISPATCH_OVERLOAD ( foo_
+                          , (typename T,typename U)
+                          , wazoo
+                          , boost::dispatch::scalar_<boost::dispatch::int8_<T>>
+                          , boost::dispatch::scalar_<boost::dispatch::int_<U>>
+                          )
   {
-    return {};
-  }
+    char operator()(T a, U b) const { return a+char(b); }
+  };
 } } }
 
 #endif

--- a/test/moc/arch/tutu/foo.hpp
+++ b/test/moc/arch/tutu/foo.hpp
@@ -13,7 +13,7 @@
 
 namespace tutu { namespace titi { namespace ext
 {
-  template<typename T> struct impl_foo<boost::dispatch::scalar_<boost::dispatch::int8_<T>>>
+  template<typename T> struct impl_foo_<boost::dispatch::scalar_<boost::dispatch::int8_<T>>>
   {
     char operator()( T ) const { return '#'; }
   };
@@ -24,7 +24,7 @@ namespace tutu { namespace titi { namespace ext
   };
 
   template<typename T>
-  impl_foo<boost::dispatch::scalar_<boost::dispatch::int8_<T>>>
+  impl_foo_<boost::dispatch::scalar_<boost::dispatch::int8_<T>>>
   dispatching_foo_( adl_helper const&, boost::dispatch::cpu_ const&
                   , boost::dispatch::scalar_<boost::dispatch::int8_<T>> const&
                   )

--- a/test/moc/tutu.hpp
+++ b/test/moc/tutu.hpp
@@ -13,9 +13,9 @@
 
 #include <boost/dispatch/function/register_namespace.hpp>
 
-namespace tutu { namespace titi
+namespace tutu { namespace titi { namespace ext
 {
-  BOOST_DISPATCH_REGISTER_NAMESPACE(ext,boost::dispatch);
-} }
+  BOOST_DISPATCH_REGISTER_NAMESPACE(boost::dispatch);
+} } }
 
 #endif

--- a/test/moc/tutu.hpp
+++ b/test/moc/tutu.hpp
@@ -15,7 +15,7 @@
 
 namespace tutu { namespace titi
 {
-  BOOST_DISPATCH_REGISTER_NAMESPACE(ext, (boost::dispatch::generic_dispatcher<Tag,Site>) );
+  BOOST_DISPATCH_REGISTER_NAMESPACE(ext,boost::dispatch);
 } }
 
 #endif

--- a/test/moc/tutu/foo.hpp
+++ b/test/moc/tutu/foo.hpp
@@ -17,7 +17,7 @@
 
 namespace tutu { namespace titi
 {
-  namespace tag { BOOST_DISPATCH_MAKE_TAG(foo_,boost::dispatch::elementwise_<foo_>); }
+  namespace tag { BOOST_DISPATCH_MAKE_TAG(ext,foo_,boost::dispatch::elementwise_<foo_>); }
   namespace ext { BOOST_DISPATCH_FUNCTION_DECLARATION(tag,foo_); }
 
   BOOST_DISPATCH_FUNCTION_DEFINITION(tag::foo_,foo);

--- a/test/moc/tutu/foo.hpp
+++ b/test/moc/tutu/foo.hpp
@@ -11,34 +11,27 @@
 #ifndef TUTU_FOO_INCLUDED
 #define TUTU_FOO_INCLUDED
 
-#include <boost/dispatch/function/callable_object.hpp>
-#include <boost/dispatch/function/functor.hpp>
+#include <boost/dispatch/function/make_callable.hpp>
+#include <boost/dispatch/hierarchy/functions.hpp>
 #include "moc/tutu.hpp"
 
 namespace tutu { namespace titi
 {
   namespace tag
   {
-    struct foo_ : boost::dispatch::function_<foo_>
+    struct foo_ : boost::dispatch::elementwise_<foo_>
     {
-      BOOST_DISPATCH_CALLABLE_OBJECT(foo_,boost::dispatch::function_<foo_>);
+      BOOST_DISPATCH_MAKE_CALLABLE(foo_,boost::dispatch::elementwise_<foo_>);
     };
   }
 
   namespace ext
   {
-    template<typename T> struct impl_foo;
-
-    template<typename Site, typename... Ts>
-    BOOST_FORCEINLINE generic_dispatcher<tag::foo_, Site>
-    BOOST_DISPATCH_DISPATCHING_FUNCTION(foo_)
-    (adl_helper const&, Site const&, boost::dispatch::type_<Ts> const&...)
-    {
-      return {};
-    }
+    BOOST_DISPATCH_FUNCTION_DECLARATION(tag,foo_);
   }
 
-  static const boost::dispatch::functor<tag::foo_> foo = {};
+  BOOST_DISPATCH_FUNCTION_DEFINITION(tag::foo_,foo);
+  BOOST_DISPATCH_FUNCTION_DEFINITION(tag::foo_,foo2);
 } }
 
 #include "moc/arch/default/foo.hpp"

--- a/test/moc/tutu/foo.hpp
+++ b/test/moc/tutu/foo.hpp
@@ -12,30 +12,8 @@
 #define TUTU_FOO_INCLUDED
 
 #include <boost/dispatch/function/callable_object.hpp>
+#include <boost/dispatch/function/functor.hpp>
 #include "moc/tutu.hpp"
-
-namespace boost { namespace dispatch
-{
-  template<typename T, typename Site = boost::dispatch::default_site<T>>
-  struct functor
-  {
-    template<typename Other> using rebind = functor<T,Other>;
-
-    template<typename OtherSite, typename... Args>
-    BOOST_FORCEINLINE BOOST_AUTO_DECLTYPE on(Args&&... args) const
-    BOOST_AUTO_DECLTYPE_BODY( T::dispatch_to( OtherSite()
-                                            , boost::dispatch::hierarchy_of_t<Args>()...
-                                            )( std::forward<Args>(args)...)
-                            )
-
-    template<typename... Args>
-    BOOST_FORCEINLINE BOOST_AUTO_DECLTYPE operator()(Args&&... args) const
-    BOOST_AUTO_DECLTYPE_BODY( T::dispatch_to( Site()
-                                            , boost::dispatch::hierarchy_of_t<Args>()...
-                                            )( std::forward<Args>(args)...)
-                            )
-  };
-} }
 
 namespace tutu { namespace titi
 {
@@ -53,7 +31,7 @@ namespace tutu { namespace titi
 
     template<typename Site, typename... Ts>
     BOOST_FORCEINLINE generic_dispatcher<tag::foo_, Site>
-    BOOST_DISPATCH_DISPATCHING_FUNCTION(foo)
+    BOOST_DISPATCH_DISPATCHING_FUNCTION(foo_)
     (adl_helper const&, Site const&, boost::dispatch::type_<Ts> const&...)
     {
       return {};

--- a/test/moc/tutu/foo.hpp
+++ b/test/moc/tutu/foo.hpp
@@ -17,21 +17,10 @@
 
 namespace tutu { namespace titi
 {
-  namespace tag
-  {
-    struct foo_ : boost::dispatch::elementwise_<foo_>
-    {
-      BOOST_DISPATCH_MAKE_CALLABLE(foo_,boost::dispatch::elementwise_<foo_>);
-    };
-  }
-
-  namespace ext
-  {
-    BOOST_DISPATCH_FUNCTION_DECLARATION(tag,foo_);
-  }
+  namespace tag { BOOST_DISPATCH_MAKE_TAG(foo_,boost::dispatch::elementwise_<foo_>); }
+  namespace ext { BOOST_DISPATCH_FUNCTION_DECLARATION(tag,foo_); }
 
   BOOST_DISPATCH_FUNCTION_DEFINITION(tag::foo_,foo);
-  BOOST_DISPATCH_FUNCTION_DEFINITION(tag::foo_,foo2);
 } }
 
 #include "moc/arch/default/foo.hpp"


### PR DESCRIPTION
Last component of Boost.Dispatch is a pre-wired system to generate function objects using tag dispatching internally. THis system uses soem macros to tie every components of the system together and provide extensions points for : 

 - all in one functor/function definition
 - tieing functor type to different named function object
 - use architectural & type dispatch to map function to implementation
